### PR TITLE
Allow USB

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,4 +57,4 @@
     name: auditd
     state: started
     enabled: yes
-  tags: service
+  tags: usb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,3 +57,4 @@
     name: auditd
     state: started
     enabled: yes
+  tags: service


### PR DESCRIPTION
Allow hardening to run on USB where you can not restart services